### PR TITLE
Make the nametag form appear earlier

### DIFF
--- a/app/css/NameTag.css
+++ b/app/css/NameTag.css
@@ -93,3 +93,8 @@
   margin-top: 5px;
   color: red;
 }
+
+:disabled {
+  background-color: #eee;
+  opacity: 0.3;
+}

--- a/app/main/page.tsx
+++ b/app/main/page.tsx
@@ -86,13 +86,12 @@ function App() {
       <div>
         <Tabs>
           <div page-label="nametag">
-            {nameTagIsLoaded && (
-              <NameTagForm
-                content={nameTagContent}
-                onNameTagContentChange={updateNameTagContent}
-                onSaveButtonClick={updateNameTagInDB}
-              />
-            )}
+            <NameTagForm
+              content={nameTagContent}
+              disabled={!nameTagIsLoaded}
+              onNameTagContentChange={updateNameTagContent}
+              onSaveButtonClick={updateNameTagInDB}
+            />
           </div>
 
           <div page-label="mindfulness">

--- a/components/NameTagForm.tsx
+++ b/components/NameTagForm.tsx
@@ -17,16 +17,20 @@ export interface NameTagContent {
 
 interface NameTagProps {
   content: NameTagContent;
+  disabled: boolean;
   onNameTagContentChange: SubmitHandler<NameTagContent>;
   onSaveButtonClick: SubmitHandler<NameTagContent>;
 }
 
 export function NameTagForm({
   content,
+  disabled,
   onNameTagContentChange,
   onSaveButtonClick,
 }: NameTagProps) {
-  const { register, handleSubmit, control, watch } = useForm<NameTagContent>();
+  const { register, handleSubmit, control, watch } = useForm<NameTagContent>({
+    disabled,
+  });
   const maxDisclosureLength = 30;
   const disclosureValue = watch("disclosure", content.disclosure ?? "");
   const isOverLimit = disclosureValue.length > maxDisclosureLength;


### PR DESCRIPTION
Previously, the entire nametag form was missing until the server responded with the values that should be loaded (if any).  I think it looks a little less jarring to start with a disabled form that then gets populated with the right values and becomes interactive after loading.

Example of what it looks like now before loading is complete:
![Screenshot 2024-11-03 at 2 57 02 PM](https://github.com/user-attachments/assets/8cc7063f-02a3-4c94-bbd7-f9d82f8d6bd4)
