### PR TITLE
Move session authentication from client to server

### DIFF
--- a/app/api/auth/users/userData/nameTag/route.ts
+++ b/app/api/auth/users/userData/nameTag/route.ts
@@ -9,12 +9,11 @@ import { getServerSession } from "next-auth/next";
  */
 
 type FetchUserNametagResponse = NextResponse<
-  | { nameTag: NameTagContent }
-  | { error: string }
+  { nameTag: NameTagContent } | { error: string }
 >;
 
 export const GET = async (): Promise<FetchUserNametagResponse> => {
-  const {userEmail, error} = await loggedInUserEmail();
+  const { userEmail, error } = await loggedInUserEmail();
 
   if (error) return NextResponse.json({ error }, { status: 400 });
 
@@ -29,25 +28,21 @@ export const GET = async (): Promise<FetchUserNametagResponse> => {
     );
   }
 
-  return NextResponse.json(
-    { nameTag: user.nameTag },
-    { status: 200 },
-  );
+  return NextResponse.json({ nameTag: user.nameTag }, { status: 200 });
 };
 
 /**
  * POST request to update the user's nametag
  */
 type UpdateUserNametagResponse = NextResponse<
-  | { success: true }
-  | { error: string }
+  { success: true } | { error: string }
 >;
 
 export const POST = async (
   req: NextRequest,
 ): Promise<UpdateUserNametagResponse> => {
   const body: object = await req.json();
-  const {userEmail, error} = await loggedInUserEmail();
+  const { userEmail, error } = await loggedInUserEmail();
   if (error) return NextResponse.json({ error }, { status: 400 });
 
   await startDB();
@@ -57,12 +52,12 @@ export const POST = async (
   return NextResponse.json({ success: true }, { status: 200 });
 };
 
-interface SessionResponse { 
-  userEmail?: string
-  error?: string,
+interface SessionResponse {
+  userEmail?: string;
+  error?: string;
 }
 
-async function loggedInUserEmail(): Promise<SessionResponse>  {
+async function loggedInUserEmail(): Promise<SessionResponse> {
   const session = await getServerSession();
   if (!session || !session.user) {
     return { error: "Session does not exist." };
@@ -71,5 +66,5 @@ async function loggedInUserEmail(): Promise<SessionResponse>  {
   if (user.email == null) {
     return { error: "User has no email." };
   }
-  return {userEmail: user.email};
+  return { userEmail: user.email };
 }

--- a/app/api/auth/users/userData/nameTag/route.ts
+++ b/app/api/auth/users/userData/nameTag/route.ts
@@ -2,31 +2,21 @@ import { NameTagContent } from "@/components/NameTagForm";
 import startDB from "@/lib/db";
 import UserModel from "@/models/userModel";
 import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth/next";
 
 /**
  * GET request to fetch the user's nametag
  */
 
-type FetchUserNametagResponse = NextResponse<{
-  success?: boolean;
-  error?: string;
-  nameTag?: NameTagContent;
-}>;
+type FetchUserNametagResponse = NextResponse<
+  | { nameTag: NameTagContent }
+  | { error: string }
+>;
 
-export const GET = async (
-  req: NextRequest,
-): Promise<FetchUserNametagResponse> => {
-  const userEmail = req.nextUrl.searchParams.get("userEmail");
+export const GET = async (): Promise<FetchUserNametagResponse> => {
+  const {userEmail, error} = await loggedInUserEmail();
 
-  if (!userEmail) {
-    return NextResponse.json(
-      {
-        success: false,
-        error: "userEmail param not specified.",
-      },
-      { status: 400 },
-    );
-  }
+  if (error) return NextResponse.json({ error }, { status: 400 });
 
   await startDB();
 
@@ -34,19 +24,13 @@ export const GET = async (
 
   if (!user) {
     return NextResponse.json(
-      {
-        success: false,
-        error: "User does not exist.",
-      },
+      { error: "User does not exist." },
       { status: 400 },
     );
   }
 
   return NextResponse.json(
-    {
-      success: true,
-      nameTag: user?.nameTag,
-    },
+    { nameTag: user.nameTag },
     { status: 200 },
   );
 };
@@ -54,25 +38,38 @@ export const GET = async (
 /**
  * POST request to update the user's nametag
  */
-
-interface UpdateUserNametagRequest {
-  email: string;
-  nameTag: NameTagContent;
-}
-
-type UpdateUserNametagResponse = NextResponse<{
-  success?: boolean;
-  error?: string;
-}>;
+type UpdateUserNametagResponse = NextResponse<
+  | { success: true }
+  | { error: string }
+>;
 
 export const POST = async (
-  req: Request,
+  req: NextRequest,
 ): Promise<UpdateUserNametagResponse> => {
-  const body = (await req.json()) as UpdateUserNametagRequest;
+  const body: object = await req.json();
+  const {userEmail, error} = await loggedInUserEmail();
+  if (error) return NextResponse.json({ error }, { status: 400 });
 
   await startDB();
 
-  await UserModel.updateOne({ email: body.email }, { nameTag: body.nameTag });
+  await UserModel.updateOne({ email: userEmail }, { nameTag: body });
 
   return NextResponse.json({ success: true }, { status: 200 });
 };
+
+interface SessionResponse { 
+  userEmail?: string
+  error?: string,
+}
+
+async function loggedInUserEmail(): Promise<SessionResponse>  {
+  const session = await getServerSession();
+  if (!session || !session.user) {
+    return { error: "Session does not exist." };
+  }
+  const user = session.user;
+  if (user.email == null) {
+    return { error: "User has no email." };
+  }
+  return {userEmail: user.email};
+}

--- a/app/main/page.tsx
+++ b/app/main/page.tsx
@@ -62,12 +62,14 @@ function App() {
   };
 
   useEffect(() => {
-    fetchNametagFromDB().then((newNameTag) => {
-      if (newNameTag !== undefined) {
-        setNameTagContent(newNameTag);
-      }
-      setNameTagIsLoaded(true);
-    }).catch((err) => console.error(err));
+    fetchNametagFromDB()
+      .then((newNameTag) => {
+        if (newNameTag !== undefined) {
+          setNameTagContent(newNameTag);
+        }
+        setNameTagIsLoaded(true);
+      })
+      .catch((err) => console.error(err));
   }, []);
 
   return (

--- a/app/main/page.tsx
+++ b/app/main/page.tsx
@@ -67,7 +67,7 @@ function App() {
         setNameTagContent(newNameTag);
       }
       setNameTagIsLoaded(true);
-    });
+    }).catch((err) => console.error(err));
   }, []);
 
   return (

--- a/cypress/e2e/login-spec.cy.ts
+++ b/cypress/e2e/login-spec.cy.ts
@@ -10,7 +10,6 @@ describe("Logging in spec", () => {
     cy.contains("Email").click().type(email);
     cy.contains("Password").click().type(password);
     cy.contains("Sign Up").click();
-    cy.wait(5000); // TODO: make this faster and remove this line
     // Sign up successful
     cy.contains("User created successfully");
 

--- a/cypress/e2e/save-nametag-spec.cy.ts
+++ b/cypress/e2e/save-nametag-spec.cy.ts
@@ -10,7 +10,6 @@ describe("Save nametag button", () => {
     cy.contains("Email").click().type(email);
     cy.contains("Password").click().type(password);
     cy.contains("Sign Up").click();
-    cy.wait(5000); // TODO: make this faster and remove this line
     // Sign up successful
     cy.contains("User created successfully");
 

--- a/lib/nametag_db.ts
+++ b/lib/nametag_db.ts
@@ -1,10 +1,9 @@
 import { NameTagContent } from "@/components/NameTagForm";
 
 export async function fetchNametagFromDB(): Promise<NameTagContent> {
-  const res = await fetch(
-    "/api/auth/users/userData/nameTag",
-    { method: "GET" },
-  );
+  const res = await fetch("/api/auth/users/userData/nameTag", {
+    method: "GET",
+  });
   const json = await res.json();
   if (json.nameTag) {
     return json.nameTag;

--- a/lib/nametag_db.ts
+++ b/lib/nametag_db.ts
@@ -1,34 +1,20 @@
 import { NameTagContent } from "@/components/NameTagForm";
-import { getSession } from "next-auth/react";
 
 export async function fetchNametagFromDB(): Promise<NameTagContent> {
-  const user = await getUser();
   const res = await fetch(
-    "/api/auth/users/userData/nameTag?userEmail=" + user.email,
+    "/api/auth/users/userData/nameTag",
     { method: "GET" },
   );
   const json = await res.json();
-  if (json.success && json.nameTag) {
+  if (json.nameTag) {
     return json.nameTag;
   }
   throw new Error("No nametag stored in DB.");
 }
 
 export async function updateNameTagInDB(newNameTag: NameTagContent) {
-  const user = await getUser();
   return fetch("/api/auth/users/userData/nameTag", {
     method: "POST",
-    body: JSON.stringify({
-      email: user.email,
-      nameTag: newNameTag,
-    }),
+    body: JSON.stringify(newNameTag),
   });
-}
-
-async function getUser() {
-  const session = await getSession();
-  if (!session || !session.user) {
-    throw new Error("User session is not defined.");
-  }
-  return session.user;
 }


### PR DESCRIPTION
This removes a round trip, and should make communicating with DB about nametags faster.

We can also remove the waits in the cypress tests now, it seems