### PR TITLE
Fix the cypress github action

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -72,7 +72,7 @@ jobs:
           build: npm run build
           start: npm start
       - name: Upload screenshots
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: cypress-screenshots


### PR DESCRIPTION
Bump the upload-artifact action to v4, since v3 is now no longer working.